### PR TITLE
Move training html so we can import video relatively

### DIFF
--- a/public/configs/config-html-MVNV.hjson
+++ b/public/configs/config-html-MVNV.hjson
@@ -36,7 +36,7 @@
             type: "training",
             stimulus: {
                 type: "website",
-                path: "training/mvnv/mvnv-training.html"
+                path: "mvnv-study/training/mvnv-training.html"
             }
         },
         trials0: {

--- a/public/html-stimuli/mvnv-study/training/mvnv-training.html
+++ b/public/html-stimuli/mvnv-study/training/mvnv-training.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <video width="800" height="300" controls>
-        <source src="/html-stimuli/mvnv-study/training/audioAdjMatrix.mp4" type="video/mp4">
+        <source src="audioAdjMatrix.mp4" type="video/mp4">
         Your browser does not support the video tag.
     </video>
 </head>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd());
 
   return {
-  base: command === 'build' ? env.VITE_BASE_PATH : '/',
+    base: command === 'build' ? env.VITE_BASE_PATH : '/',
     plugins: [
       react(),
     ],


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
The training wasn't loading on prod because of an absolute import that was broken. By moving some files around, I can do a relative import, which should fix it.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No